### PR TITLE
Add markdown export route for posts

### DIFF
--- a/app/[owner]/[repo]/[postNumber]/post.md/route.ts
+++ b/app/[owner]/[repo]/[postNumber]/post.md/route.ts
@@ -21,9 +21,6 @@ function convertMessagesToMarkdown(messages: AgentUIMessage[]): string {
             if (part.type === "text") {
               return part.text
             }
-            if (part.type === "image") {
-              return `![Image](${part.image})`
-            }
             return ""
           })
           .filter(Boolean)


### PR DESCRIPTION
Implements `/owner/repo/postNumber/post.md` route that returns LLM-friendly markdown format of the entire conversation.

Closes #15

Generated with [Claude Code](https://claude.ai/code)