### PR TITLE
fix: use updateTag server action for cache invalidation after streams

### DIFF
--- a/agent/category-agent.ts
+++ b/agent/category-agent.ts
@@ -1,7 +1,7 @@
 import { stepCountIs, streamText, tool } from "ai"
 import { eq } from "drizzle-orm"
-import { revalidateTag } from "next/cache"
 import { z } from "zod"
+import { revalidateAfterStream } from "@/lib/actions/posts"
 import { db } from "@/lib/db/client"
 import { categories, posts } from "@/lib/db/schema"
 import { updatePostIndex } from "@/lib/typesense-index"
@@ -117,6 +117,5 @@ You're working on your own. Meaning, the user won't be able to respond any quest
     ...(categoryId && { categoryId }),
   })
 
-  revalidateTag(`repo:${owner}:${repo}`, "max")
-  revalidateTag(`post:${postId}`, "max")
+  await revalidateAfterStream({ owner, repo, postId })
 }

--- a/agent/response-agent.ts
+++ b/agent/response-agent.ts
@@ -6,8 +6,8 @@ import {
 } from "ai"
 import { asc, eq } from "drizzle-orm"
 import { nanoid } from "nanoid"
-import { revalidateTag } from "next/cache"
 import { getWritable } from "workflow"
+import { revalidateAfterStream } from "@/lib/actions/posts"
 import { db } from "@/lib/db/client"
 import { comments } from "@/lib/db/schema"
 import { getTools } from "./tools"
@@ -174,6 +174,5 @@ async function closeStreamStep({
       .where(eq(comments.id, commentId)),
   ])
 
-  revalidateTag(`repo:${owner}:${repo}`, "max")
-  revalidateTag(`post:${postId}`, "max")
+  await revalidateAfterStream({ owner, repo, postId })
 }

--- a/lib/actions/posts.ts
+++ b/lib/actions/posts.ts
@@ -399,6 +399,19 @@ export async function removeReaction({
   updateTag(`post:${postId}`)
 }
 
+export async function revalidateAfterStream({
+  owner,
+  repo,
+  postId,
+}: {
+  owner: string
+  repo: string
+  postId: string
+}) {
+  updateTag(`repo:${owner}:${repo}`)
+  updateTag(`post:${postId}`)
+}
+
 export async function getPostMetadata(postId: string) {
   const [post] = await db
     .select({


### PR DESCRIPTION
Replace revalidateTag calls with a new revalidateAfterStream server action that uses updateTag. This ensures proper cache invalidation when refreshing right after a stream completes, fixing the issue where full comments weren't showing up on refresh.

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)