### PR TITLE
Add tooltip and link to author avatar in post list

### DIFF
--- a/app/[owner]/[repo]/active-posts.tsx
+++ b/app/[owner]/[repo]/active-posts.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { List, ListItem, TableCellText } from "@/components/typography"
 import type { categories } from "@/lib/db/schema"
 import { formatRelativeTime } from "@/lib/utils"
+import { AuthorAvatar } from "./author-avatar"
 
 type PostListItem = {
   id: string
@@ -55,11 +56,7 @@ export function ActivePosts({
             <div className="flex shrink-0 items-center">
               {!!post.authorUsername && (
                 <TableCellText className="relative mr-2 h-full w-(--col-w-avatar)">
-                  <img
-                    alt={post.authorUsername}
-                    className="-translate-y-1/2 absolute top-1/2 h-6 w-6 rounded-full"
-                    src={`https://github.com/${post.authorUsername}.png`}
-                  />
+                  <AuthorAvatar username={post.authorUsername} />
                 </TableCellText>
               )}
               <TableCellText className="w-(--col-w-time) text-end">

--- a/app/[owner]/[repo]/author-avatar.tsx
+++ b/app/[owner]/[repo]/author-avatar.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { Tooltip } from "@base-ui/react/tooltip"
+import Link from "next/link"
+
+export function AuthorAvatar({ username }: { username: string }) {
+  return (
+    <Tooltip.Provider>
+      <Tooltip.Root>
+        <Tooltip.Trigger
+          render={
+            <Link href={`/user/${username}`}>
+              <img
+                alt={username}
+                className="-translate-y-1/2 absolute top-1/2 h-6 w-6 rounded-full"
+                src={`https://github.com/${username}.png`}
+              />
+            </Link>
+          }
+        />
+        <Tooltip.Portal>
+          <Tooltip.Positioner>
+            <Tooltip.Popup>{username}</Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  )
+}


### PR DESCRIPTION
The author avatar in the repo index page now links to the user's
profile page and shows their username in a tooltip on hover.