### PR TITLE
feat: add loading state to sign-in button

### DIFF
--- a/components/sign-in-button.tsx
+++ b/components/sign-in-button.tsx
@@ -1,20 +1,25 @@
 "use client"
+import { useState } from "react"
 import { usePathname } from "next/navigation"
 import { authClient } from "@/lib/auth-client"
 import { Button } from "./button"
 
 export const SignInButton = () => {
   const pathname = usePathname()
+  const [isLoading, setIsLoading] = useState(false)
+
   return (
     <Button
-      onClick={() =>
+      onClick={() => {
+        setIsLoading(true)
         authClient.signIn.social({ provider: "github", callbackURL: pathname })
-      }
+      }}
       size="sm"
       type="button"
       variant="secondary"
+      disabled={isLoading}
     >
-      Log In
+      {isLoading ? "Loading…" : "Log In"}
     </Button>
   )
 }


### PR DESCRIPTION
Shows "Loading…" and disables the button while the OAuth redirect
is being processed, giving users visual feedback.