### PR TITLE
fix: use specific storage key for post page composer

### DIFF
--- a/app/[owner]/[repo]/[postNumber]/page.tsx
+++ b/app/[owner]/[repo]/[postNumber]/page.tsx
@@ -317,7 +317,7 @@ export default async function PostPage({
         <PostComposer
           askingOptions={askingOptions}
           postId={post.id}
-          storageKey={`composer:${post.id}`}
+          storageKey={`post-composer:${owner}:${repo}:${post.number}`}
         />
       </Container>
     </PostMetadataProvider>


### PR DESCRIPTION
Change the sessionStorage key from `composer:${post.id}` to
`post-composer:${owner}:${repo}:${post.number}` for better
consistency with the URL structure and to ensure uniqueness.