### PR TITLE
fix: filter categories by both owner and repo in category agent

### DIFF
--- a/agent/category-agent.ts
+++ b/agent/category-agent.ts
@@ -1,5 +1,5 @@
 import { stepCountIs, streamText, tool } from "ai"
-import { eq } from "drizzle-orm"
+import { and, eq } from "drizzle-orm"
 import { updateTag } from "next/cache"
 import { z } from "zod"
 import { db } from "@/lib/db/client"
@@ -25,7 +25,7 @@ export async function runCategoryAgent({
       emoji: categories.emoji,
     })
     .from(categories)
-    .where(eq(categories.owner, owner))
+    .where(and(eq(categories.owner, owner), eq(categories.repo, repo)))
 
   const result: {
     title: string
@@ -105,7 +105,13 @@ You're working on your own. Meaning, the user won't be able to respond any quest
     const inserted = await db
       .select({ id: categories.id })
       .from(categories)
-      .where(eq(categories.title, result.newCategory.title))
+      .where(
+        and(
+          eq(categories.owner, owner),
+          eq(categories.repo, repo),
+          eq(categories.title, result.newCategory.title)
+        )
+      )
       .limit(1)
     categoryId = inserted[0]?.id
   }


### PR DESCRIPTION
The category agent was only filtering by owner when fetching existing categories, which caused posts to be assigned to categories from different repos under the same owner. Additionally, when looking up a newly created category, it only filtered by title.

Both queries now filter by owner, repo, and title to ensure posts are assigned to the correct repo's categories.