### PR TITLE
Pre-fill category when creating new post

### DIFF
--- a/agent/category-agent.ts
+++ b/agent/category-agent.ts
@@ -12,30 +12,35 @@ export async function runCategoryAgent({
   owner,
   repo,
   content,
+  existingCategoryId,
 }: {
   postId: string
   owner: string
   repo: string
   content: string
+  existingCategoryId?: string
 }) {
-  const existingCategories = await db
-    .select({
-      id: categories.id,
-      title: categories.title,
-      emoji: categories.emoji,
-    })
-    .from(categories)
-    .where(and(eq(categories.owner, owner), eq(categories.repo, repo)))
-
   const result: {
     title: string
     categoryId?: string
     newCategory?: { title: string; emoji: string }
   } = { title: "" }
 
-  const stream = streamText({
-    model: "anthropic/claude-haiku-4.5",
-    system: `You are a forum assistant. Given a post's content, you must:
+  const needsCategory = !existingCategoryId
+
+  const existingCategories = needsCategory
+    ? await db
+        .select({
+          id: categories.id,
+          title: categories.title,
+          emoji: categories.emoji,
+        })
+        .from(categories)
+        .where(and(eq(categories.owner, owner), eq(categories.repo, repo)))
+    : []
+
+  const systemPrompt = needsCategory
+    ? `You are a forum assistant. Given a post's content, you must:
 1. Set a concise post title (10 words max) using setTitle.
    - If the user is asking something, seeking help, or describing a problem they want solved, frame the title as a question (e.g. "How can I do X with Y?" or "Why does X happen when Y?")
    - Only use statement-style titles for announcements, discussions, or purely informational posts
@@ -45,44 +50,59 @@ export async function runCategoryAgent({
 Existing categories:
 ${existingCategories.length ? existingCategories.map((c) => `- ${c.emoji || ""} ${c.title} (id: ${c.id})`).join("\n") : "(none yet)"}
 
-You're working on your own. Meaning, the user won't be able to respond any question you might have. They'll send in the only info they have available at this time.`,
+You're working on your own. Meaning, the user won't be able to respond any question you might have. They'll send in the only info they have available at this time.`
+    : `You are a forum assistant. Given a post's content, set a concise post title (10 words max) using setTitle.
+- If the user is asking something, seeking help, or describing a problem they want solved, frame the title as a question (e.g. "How can I do X with Y?" or "Why does X happen when Y?")
+- Only use statement-style titles for announcements, discussions, or purely informational posts
+- Try to always set a title that accurately reflects the post content, even if you can't possibly frame it as a question
+
+You're working on your own. The category has already been set.`
+
+  const tools: Parameters<typeof streamText>[0]["tools"] = {
+    setTitle: tool({
+      description: "Set the post title",
+      inputSchema: z.object({ title: z.string() }),
+      // biome-ignore lint/suspicious/useAwait: .
+      execute: async (params) => {
+        result.title = params.title
+        return { ok: true }
+      },
+    }),
+  }
+
+  if (needsCategory) {
+    tools.setCategory = tool({
+      description: "Set an existing category by ID",
+      inputSchema: z.object({ categoryId: z.string() }),
+      // biome-ignore lint/suspicious/useAwait: .
+      execute: async (params) => {
+        result.categoryId = params.categoryId
+        return { ok: true }
+      },
+    })
+    tools.createAndSetCategory = tool({
+      description:
+        "Create a new category and set it. Use broad categories like 'Bugs', 'Feature Requests', 'Questions', 'Discussions'",
+      inputSchema: z.object({
+        title: z
+          .string()
+          .describe("Human-readable title like 'Feature Requests'"),
+        emoji: z.string().describe("Single emoji for the category icon"),
+      }),
+      // biome-ignore lint/suspicious/useAwait: .
+      execute: async (cat) => {
+        result.newCategory = cat
+        result.newCategory.title = result.newCategory.title.toLowerCase()
+        return { ok: true }
+      },
+    })
+  }
+
+  const stream = streamText({
+    model: "anthropic/claude-haiku-4.5",
+    system: systemPrompt,
     prompt: `Here's the post content:\n\n${content}`,
-    tools: {
-      setTitle: tool({
-        description: "Set the post title",
-        inputSchema: z.object({ title: z.string() }),
-        // biome-ignore lint/suspicious/useAwait: .
-        execute: async (params) => {
-          result.title = params.title
-          return { ok: true }
-        },
-      }),
-      setCategory: tool({
-        description: "Set an existing category by ID",
-        inputSchema: z.object({ categoryId: z.string() }),
-        // biome-ignore lint/suspicious/useAwait: .
-        execute: async (params) => {
-          result.categoryId = params.categoryId
-          return { ok: true }
-        },
-      }),
-      createAndSetCategory: tool({
-        description:
-          "Create a new category and set it. Use broad categories like 'Bugs', 'Feature Requests', 'Questions', 'Discussions'",
-        inputSchema: z.object({
-          title: z
-            .string()
-            .describe("Human-readable title like 'Feature Requests'"),
-          emoji: z.string().describe("Single emoji for the category icon"),
-        }),
-        // biome-ignore lint/suspicious/useAwait: .
-        execute: async (cat) => {
-          result.newCategory = cat
-          result.newCategory.title = result.newCategory.title.toLowerCase()
-          return { ok: true }
-        },
-      }),
-    },
+    tools,
     stopWhen: stepCountIs(10),
   })
 

--- a/app/[owner]/[repo]/category/[categorySlug]/page.tsx
+++ b/app/[owner]/[repo]/category/[categorySlug]/page.tsx
@@ -141,6 +141,7 @@ export default async function CategoryPage({
             })),
             { id: "human", name: "Human only" },
           ]}
+          categoryId={category.id}
           owner={owner}
           repo={repo}
         />

--- a/app/[owner]/[repo]/new-post-composer.tsx
+++ b/app/[owner]/[repo]/new-post-composer.tsx
@@ -11,10 +11,12 @@ export function NewPostComposer({
   owner,
   repo,
   askingOptions,
+  categoryId,
 }: {
   owner: string
   repo: string
   askingOptions: ComposerProps["options"]["asking"]
+  categoryId?: string
 }) {
   const router = useRouter()
   const [defaultLlmId, setDefaultLlmId] = useState<string | undefined>()
@@ -43,6 +45,7 @@ export function NewPostComposer({
             parts: [{ type: "text", text: value }],
           },
           seekingAnswerFrom: options.asking.id,
+          categoryId,
         })
         router.push(`/${owner}/${repo}/${result.postNumber}`)
       }}

--- a/lib/actions/posts.ts
+++ b/lib/actions/posts.ts
@@ -151,6 +151,7 @@ export async function createPost(data: {
   repo: string
   content: AgentUIMessage
   seekingAnswerFrom?: string | null
+  categoryId?: string
 }) {
   const session = await getSessionOrThrow()
   const authorUsername = await getGitHubUsername(session.user.image)
@@ -199,6 +200,7 @@ export async function createPost(data: {
             repo: data.repo,
             authorId: session.user.id,
             rootCommentId: commentId,
+            categoryId: data.categoryId,
             createdAt: now,
             updatedAt: now,
           })
@@ -283,6 +285,7 @@ export async function createPost(data: {
       owner: data.owner,
       repo: data.repo,
       content: contentText,
+      existingCategoryId: data.categoryId,
     })
   }
 


### PR DESCRIPTION
- Pass categoryId from category page to NewPostComposer
- Accept categoryId in createPost and set on new post
- Category-agent now skips category selection if already provided