### PR TITLE
Fix layout shift in post index page

### DIFF
--- a/app/[owner]/[repo]/active-posts.tsx
+++ b/app/[owner]/[repo]/active-posts.tsx
@@ -57,7 +57,7 @@ export function ActivePosts({
                       <AuthorAvatar username={post.authorUsername} />
                     </TableCellText>
                   )}
-                  <TableCellText className="text-end text-sm">
+                  <TableCellText className="min-w-16 text-end text-sm">
                     <RelativeTime timestamp={post.createdAt} />
                   </TableCellText>
                 </div>


### PR DESCRIPTION
Both AuthorAvatar and RelativeTime are client components that cause layout shift during hydration. Wrapping them together in a single Suspense boundary with skeleton fallbacks reserves the space.