### PR TITLE
Remove streaming indicator after comment stream ends

### DIFF
--- a/app/[owner]/[repo]/[postNumber]/streaming-content.tsx
+++ b/app/[owner]/[repo]/[postNumber]/streaming-content.tsx
@@ -41,6 +41,12 @@ export function StreamingContent({ commentId }: { commentId: string }) {
   const isStreaming = status === "streaming" || status === "submitted"
   const lastMessage = messages.at(-1)
 
+  useEffect(() => {
+    if (status === "ready" && started.current) {
+      router.refresh()
+    }
+  }, [status, router])
+
   function handleRetry() {
     startTransition(async () => {
       await rerunLlmComment({ commentId })


### PR DESCRIPTION
When streaming finishes, the server sets streamId to null, but the client component was showing stale data. Now calls router.refresh() when status becomes 'ready' to get updated comment state.