### PR TITLE
fix: use NEXT_PUBLIC_ prefix for Vercel env vars in getSiteOrigin

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -13,11 +13,11 @@ export const nanoid = customAlphabet(
 )
 
 export function getSiteOrigin() {
-  if (process.env.VERCEL_ENV === "production") {
-    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+  if (process.env.NEXT_PUBLIC_VERCEL_ENV === "production") {
+    return `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`
   }
-  if (process.env.VERCEL_BRANCH_URL) {
-    return `https://${process.env.VERCEL_BRANCH_URL}`
+  if (process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL) {
+    return `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
   }
   return "http://localhost:3000"
 }


### PR DESCRIPTION
Makes vars accessible on both server and client side.