### PR TITLE
fix: improve credits-related copy in composer

### DIFF
--- a/components/composer.tsx
+++ b/components/composer.tsx
@@ -224,13 +224,13 @@ export const Composer = ({
                 if (creditBalance === 0) {
                   return (
                     <span className="text-red-500 text-xs">
-                      You have run out of credits
+                      Out of credits
                     </span>
                   )
                 }
                 return (
                   <span className="text-red-500 text-xs">
-                    You have less than the required 5 credits to use this model
+                    Not enough credits for this model
                   </span>
                 )
               }


### PR DESCRIPTION
Simplified the verbose "You have run out of credits" and "You have less than the required 5 credits to use this model" to cleaner, more concise messages.