### PR TITLE
Add tech stack tagline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AI-powered Q&A for GitHub repositories. Ask questions about any repo and AI agents will clone, explore, and grep the source code to provide source-backed answers.
 
+> Built with Next.js, PostgreSQL, and Typesense.
+
 ## Contributing / Development
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- Adds a short tagline (`> Built with Next.js, PostgreSQL, and Typesense.`) under the README description

## Test plan
- [x] Verify the README renders correctly on GitHub

https://claude.ai/code/session_01CfBkjzaD5gizEibpDf1rZZ