### PR TITLE
feat: auto-focus inputs on typing and pasting

### DIFF
--- a/apps/web/components/composer.tsx
+++ b/apps/web/components/composer.tsx
@@ -19,6 +19,7 @@ import GeminiIcon from "@/components/icons/gemini"
 import OpenAIIcon from "@/components/icons/openai"
 import { Menu } from "@/components/ui/menu"
 import { authClient } from "@/lib/auth-client"
+import { useAutoFocusOnType } from "@/lib/hooks/use-auto-focus-on-type"
 import { useDialogStore } from "@/lib/stores/dialogs"
 import { cn } from "@/lib/utils"
 import { Button } from "./button"
@@ -177,6 +178,8 @@ export const Composer = ({
       textareaRef.current?.focus()
     }
   }, [autoFocus])
+
+  useAutoFocusOnType(textareaRef)
 
   return (
     <form

--- a/apps/web/components/repo-list-with-search.tsx
+++ b/apps/web/components/repo-list-with-search.tsx
@@ -10,6 +10,7 @@ import {
   TableCellText,
   TableColumnTitle,
 } from "@/components/typography"
+import { useAutoFocusOnType } from "@/lib/hooks/use-auto-focus-on-type"
 import { formatCompactNumber, formatRelativeTime } from "@/lib/utils"
 
 type RepoStats = {
@@ -88,6 +89,8 @@ export function RepoListWithSearch({
   useEffect(() => {
     inputRef.current?.focus()
   }, [])
+
+  useAutoFocusOnType(inputRef)
 
   useEffect(() => {
     const query = value.trim()

--- a/apps/web/components/repo-search-input.tsx
+++ b/apps/web/components/repo-search-input.tsx
@@ -4,6 +4,7 @@ import { SearchIcon } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useEffect, useRef, useState } from "react"
+import { useAutoFocusOnType } from "@/lib/hooks/use-auto-focus-on-type"
 
 function parseRepoInput(input: string): { owner: string; repo: string } | null {
   const trimmed = input.trim()
@@ -41,6 +42,8 @@ export function RepoSearchInput({ autoFocus }: { autoFocus?: boolean }) {
       inputRef.current?.focus()
     }
   }, [autoFocus])
+
+  useAutoFocusOnType(inputRef)
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()

--- a/apps/web/lib/hooks/use-auto-focus-on-type.ts
+++ b/apps/web/lib/hooks/use-auto-focus-on-type.ts
@@ -1,0 +1,114 @@
+import { type RefObject, useEffect } from "react"
+
+/**
+ * Auto-focuses the target input/textarea when the user starts typing or pastes,
+ * but only if no other interactive element is currently focused.
+ *
+ * This avoids stealing focus from other inputs, textareas, selects, buttons,
+ * contenteditable elements, or elements inside dialogs/menus.
+ */
+export function useAutoFocusOnType(
+  ref: RefObject<HTMLInputElement | HTMLTextAreaElement | null>
+) {
+  useEffect(() => {
+    function shouldIgnore(): boolean {
+      const active = document.activeElement
+      if (!active || active === document.body) {
+        return false
+      }
+
+      const tag = active.tagName
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT"
+      ) {
+        return true
+      }
+
+      if ((active as HTMLElement).isContentEditable) {
+        return true
+      }
+
+      // Don't steal focus from elements inside dialogs, menus, or popovers
+      if (
+        active.closest(
+          '[role="dialog"], [role="menu"], [role="listbox"], [role="combobox"], [data-popup]'
+        )
+      ) {
+        return true
+      }
+
+      return false
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      // Don't interfere if the target element already has focus
+      if (document.activeElement === ref.current) {
+        return
+      }
+
+      // Don't intercept if modifier keys are held (except Shift for uppercase)
+      if (e.metaKey || e.ctrlKey || e.altKey) {
+        return
+      }
+
+      // Only intercept printable single characters
+      if (e.key.length !== 1) {
+        return
+      }
+
+      if (shouldIgnore()) {
+        return
+      }
+
+      ref.current?.focus()
+      // Don't prevent default — the character will be typed into the now-focused element
+    }
+
+    function handlePaste(e: ClipboardEvent) {
+      if (document.activeElement === ref.current) {
+        return
+      }
+
+      if (shouldIgnore()) {
+        return
+      }
+
+      const text = e.clipboardData?.getData("text")
+      if (!text) {
+        return
+      }
+
+      e.preventDefault()
+
+      const el = ref.current
+      if (!el) return
+
+      el.focus()
+
+      // Use native value setter + input event to work with React controlled components.
+      // React overrides the value property on inputs, so we need to call the native
+      // HTMLInputElement/HTMLTextAreaElement setter to bypass React's controlled value,
+      // then dispatch an input event so React's onChange fires.
+      const proto =
+        el instanceof HTMLTextAreaElement
+          ? HTMLTextAreaElement.prototype
+          : HTMLInputElement.prototype
+      const nativeSetter = Object.getOwnPropertyDescriptor(proto, "value")?.set
+      if (nativeSetter) {
+        const currentValue = el.value
+        nativeSetter.call(el, currentValue + text)
+        el.dispatchEvent(new Event("input", { bubbles: true }))
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    document.addEventListener("paste", handlePaste)
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown)
+      document.removeEventListener("paste", handlePaste)
+    }
+  }, [ref])
+}


### PR DESCRIPTION
Add a useAutoFocusOnType hook that automatically focuses the main
input/textarea when the user starts typing or pastes text, without
stealing focus from other interactive elements.

The hook:
- Listens for keydown (printable characters only) and paste events
- Skips if another input, textarea, select, or contenteditable is focused
- Skips if focus is inside a dialog, menu, listbox, combobox, or popup
- Skips if modifier keys (Cmd/Ctrl/Alt) are held (Shift is allowed)
- For paste, uses native value setter to work with React controlled inputs

Applied to:
- Composer (textarea on repo page and post page)
- RepoListWithSearch (search input on homepage)
- RepoSearchInput (standalone search input)
